### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -1,4 +1,6 @@
 name: Docker Build
+permissions:
+  contents: read
 on:
   push:
     branches: ["master", "main"]


### PR DESCRIPTION
Potential fix for [https://github.com/gvatsal60/rustify/security/code-scanning/2](https://github.com/gvatsal60/rustify/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves checking out the repository and running build/test commands, it only requires `contents: read` permissions. This change should be applied at the root level of the workflow to cover all jobs unless specific jobs require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
