### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/readme-checker.yaml
+++ b/.github/workflows/readme-checker.yaml
@@ -1,4 +1,6 @@
 name: markdown-lint
+permissions:
+  contents: read
 on:
   pull_request:
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/gvatsal60/rustify/security/code-scanning/1](https://github.com/gvatsal60/rustify/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs a linting task and does not require write access, we will set `contents: read` as the minimal required permission. This ensures the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
